### PR TITLE
Fix building on OS X 10.9 Maverics (clang-600.0.56) with Homebrew

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -141,6 +141,9 @@ function unpack_sources {
 
   unpack_clean "${VLINK}" "${VLINK_SRC}"
   mv "vlink" "${VLINK}"
+  pushd "${VLINK}"
+  mkdir objects
+  popd
 
   unpack_clean "${VBCC}" "${VBCC_SRC}"
   mv "vbcc" "${VBCC}"

--- a/patches/vbcc-0.9b/fix-asm-keyword.diff
+++ b/patches/vbcc-0.9b/fix-asm-keyword.diff
@@ -1,0 +1,34 @@
+--- vbcc/declaration.c	2015-01-03 15:15:27.000000000 +0100
++++ vbcc/declaration.c	2015-01-05 17:37:49.000000000 +0100
+@@ -3431,7 +3431,7 @@
+ }
+ 
+ /* declare a builtin function with up to two scalar arguments */
+-struct Var *declare_builtin(char *name,int ztyp,int q1typ,int q1reg,int q2typ,int q2reg,int nosidefx,char *asm)
++struct Var *declare_builtin(char *name,int ztyp,int q1typ,int q1reg,int q2typ,int q2reg,int nosidefx,char *_asm)
+ {
+   struct struct_declaration *sd;
+   struct Typ *t;
+@@ -3464,9 +3464,9 @@
+     t->next->flags=ztyp;
+     v=add_var(name,t,EXTERN,0);
+     v->flags|=BUILTIN;
+-    if(asm||nosidefx){
++    if(_asm||nosidefx){
+       v->fi=new_fi();
+-      if(asm) v->fi->inline_asm=asm;
++      if(_asm) v->fi->inline_asm=_asm;
+       if(nosidefx){
+ 	v->fi->call_cnt=v->fi->use_cnt=v->fi->change_cnt=0;
+ 	v->fi->flags=ALL_CALLS|ALL_USES|ALL_MODS|ALWAYS_RETURNS|NOSIDEFX;
+--- vbcc/supp.h	2015-01-03 15:15:27.000000000 +0100
++++ vbcc/supp.h	2015-01-05 17:37:56.000000000 +0100
+@@ -677,7 +677,7 @@
+ extern int is_volatile_ic(struct IC *);
+ extern struct case_table *calc_case_table(struct IC *,double);
+ int calc_regs(struct IC *,int);
+-struct Var *declare_builtin(char *name,int ztyp,int q1typ,int q1reg,int q2typ,int q2reg,int nosidefx,char *asm);
++struct Var *declare_builtin(char *name,int ztyp,int q1typ,int q1reg,int q2typ,int q2reg,int nosidefx,char *_asm);
+ extern void emit_jump_table(FILE *,struct case_table *,char *,char *,int);
+ extern void optimize(long, struct Var *);
+ int bvcmp(bvtype *dest,bvtype *src,size_t len);


### PR DESCRIPTION
Hi,

Here's a couple of fixes to build the project. I'm not entirely sure why **vlink** compilation worked properly earlier, but I've tested it on 2 machines and now both of them exhibit a problem with missing "objects" directory:
```
gcc -o 	objects/main.o -std=c9x -O2 -fomit-frame-pointer -c  main.c
Assembler messages:
Fatal error: can't create objects/main.o: No such file or directory
make: *** [objects/main.o] Error 1
argasek@somewhere:~/vlink$ gcc --version
gcc (Debian 4.4.5-8) 4.4.5
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```
Same happens on OS X 10.9.5 with Homebrew.

The second patch is probably related to the new version of LLVM, which fails to compile **vbcc** with something like this:
```
/supp.h:680:108: error: expected ')'
struct Var *declare_builtin(char *name,int ztyp,int q1typ,int q1reg,int q2typ,int q2reg,int nosidefx,char *asm);
```
because *asm* is being interpreted as a reserved keyword.
